### PR TITLE
Update WithWriteStream to wait for the stream to finish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiggly-games/files",
-  "version": "1.0.3",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiggly-games/files",
-      "version": "1.0.3",
+      "version": "1.1.2",
       "license": "ISC",
       "dependencies": {
         "fs": "^0.0.1-security"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiggly-games/files",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "main": "src/Files.js",
   "scripts": {

--- a/src/Files.ts
+++ b/src/Files.ts
@@ -117,9 +117,21 @@ export async function WithReadStream(filePath: string, f: (stream: fs.ReadStream
 // Returns a function for working with a Write Stream.
 // Opens the write stream, runs the function, then closes the stream and returns the result.
 export async function WithWriteStream(filePath: string, f: (stream: fs.WriteStream)=>Promise<any>): Promise<any> {
-    const stream = fs.createWriteStream(filePath);
-    const result = await f(stream);
+    return new Promise<any>(async (fulfill, reject) => {
+        try {
+            const stream = fs.createWriteStream(filePath);
+            const result = await f(stream);
 
-    stream.end();
-    return result;
+            stream.end();
+
+            stream.on('finish', ()=>{
+                fulfill(result);
+            });
+            stream.on('error', (e)=>{
+                reject(e);
+            })
+        } catch(e) {
+            reject(e);
+        }
+    });
 }

--- a/test.ts
+++ b/test.ts
@@ -2,5 +2,12 @@ import * as Files from "./src/Files";
 
 
 (async () => {
-    console.log(Files.GetFileName("..\\TrainingData\\WeirdAl.json"));
+    await Files.WithWriteStream("./data/Test.txt", async (stream) => {
+        await stream.write("Test 1");
+        await stream.write("Test 2");
+        await stream.write("Test 3");
+        return null;
+    })
+    const data = await Files.ReadFile("./data/Test.txt");
+    console.log(data.toString());
 })();


### PR DESCRIPTION
The stream was ending before the writing was completed, which would cause issues later if we tried to read data. Now waiting for the write to finish before returning back to the calling method.